### PR TITLE
Switch from array of bytes to bytearray for perf reasons

### DIFF
--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -122,7 +122,7 @@ class open(OpenBase):
             return ''
         r = self.process.stdout
         self.process.stdin.flush()
-        out = b""
+        out = bytearray()
         foo = None
         while True:
             try:


### PR DESCRIPTION
Use bytearray instead of array of bytes for perf reasons.